### PR TITLE
Use new Var constructor for js expressions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "reflex-chakra"
-version = "0.6.0"
+version = "0.6.1"
 description = "reflex using chakra components"
 authors = [
     "Elijah Ahianyo <elijah@reflex.dev>"

--- a/reflex_chakra/components/base.py
+++ b/reflex_chakra/components/base.py
@@ -98,7 +98,7 @@ class ChakraProvider(ChakraComponent):
             A new ChakraProvider component.
         """
         return super().create(
-            theme=Var.create("extendTheme(theme)"),
+            theme=Var("extendTheme(theme)", _var_type=str),
         )
 
     def add_imports(self) -> ImportDict:

--- a/reflex_chakra/components/navigation/link.py
+++ b/reflex_chakra/components/navigation/link.py
@@ -24,7 +24,7 @@ class Link(ChakraComponent):
     text: Var[str]
 
     # What the link renders to.
-    as_: Var[Component] = Var.create("NextLink").to(Component)
+    as_: Var[Component] = Var("NextLink", _var_type=Component)
 
     # If true, the link will open in new tab.
     is_external: Var[bool]


### PR DESCRIPTION
`Var.create` is used to convert python literals to js expressions, but these values are already js expressions, so use them directly.